### PR TITLE
Fix a dead end in the contribution flow, plus two small correctness fixes

### DIFF
--- a/app/components/ContributionEditor.tsx
+++ b/app/components/ContributionEditor.tsx
@@ -783,6 +783,7 @@ export default function ContributionEditor({
         'contributor_banned',
         'contributor_muted',
         'auth_unavailable',
+        'duplicate_image_marker',
         'image_alt_required',
         'image_expired_or_forbidden',
         'image_metadata_required',
@@ -1286,6 +1287,12 @@ export default function ContributionEditor({
                                 'একটি ছবি লেখার মধ্যে আর নেই। ছবির তালিকা থেকে সেটি সরান, অথবা আবার লেখায় বসান।',
                                 'One attached image is no longer in the article. Remove it from the image list or insert it again.'
                               )
+                            : submitError === 'duplicate_image_marker'
+                              ? t(
+                                  isEn,
+                                  'একই ছবি লেখায় দুবার বসানো আছে। বাড়তি কপিটি মুছে আবার পাঠান।',
+                                  'The same image appears twice in the article. Delete the extra copy and send again.'
+                                )
                             : submitError === 'image_expired_or_forbidden'
                               ? t(
                                   isEn,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "packageManager": "npm@10.9.2",
   "type": "module",
+  "engines": {
+    "node": ">=22.6.0"
+  },
   "scripts": {
     "dev": "node scripts/dev.mjs",
     "dev:turbo": "node scripts/dev.mjs --turbopack",

--- a/worker/api/contribution-review.ts
+++ b/worker/api/contribution-review.ts
@@ -161,7 +161,7 @@ async function decideImage(
     })
     await Promise.all([
       bindings.quarantine.delete(media.objectKey),
-      bindings.guards.delete(`media:${media.id}`)
+      bindings.guards.delete(mediaRecordKey(media.id))
     ])
     record.media[index] = {
       ...media,
@@ -248,7 +248,7 @@ async function decideImage(
 
   await Promise.all([
     bindings.quarantine.delete(media.objectKey),
-    bindings.guards.delete(`media:${media.id}`)
+    bindings.guards.delete(mediaRecordKey(media.id))
   ])
   record.media[index] = {
     ...media,


### PR DESCRIPTION
Three small fixes from testing the contribution flow.

Main one: pasting the same image twice made submit fail with a generic retry message forever, because `duplicate_image_marker` was never handled in the editor. Also tidies two KV key call sites and declares the Node version the test scripts already need.

Checks pass.
