### PR TITLE
Add accessible change review to the browser editor

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -251,7 +251,10 @@ instead.
 
 **The Frugal-Yellow Rule.** Yellow belongs to cautions and the one toggle thumb. It is never a
 highlight or a decoration. Its scarcity is what lets a stub banner read as unfinished rather than
-broken.
+broken. The on-demand contribution diff is the sole semantic exception: Notice Gold and Notice
+Cream identify removed text, always paired with a minus marker and a spoken “removed” label so
+color never carries the meaning alone. This exception does not make yellow available as a general
+highlight.
 
 **The Earned-Violet Rule.** The violet is the only color in this palette justified by a reader
 behavior rather than a role. It may not be borrowed for anything that is not literally "you have

--- a/app/components/ContributionDiffDialog.module.css
+++ b/app/components/ContributionDiffDialog.module.css
@@ -1,0 +1,330 @@
+/* ------------------------------------------------- review changes dialog */
+/* The contributor edited rendered prose, never Markdown source, so this sheet
+   has to answer one question — "what did I actually change?" — without asking
+   them to read a patch. Line numbers are gone, the @@ header is gone, and the
+   words that moved carry the mark. What is left is the site's own paper: white
+   canvas, hairline rules, the green top edge every dialog here wears. */
+
+.card {
+  position: relative;
+  display: flex;
+  width: min(100%, 920px);
+  max-height: calc(100vh - 48px);
+  max-height: calc(100dvh - 48px);
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-top: 5px solid var(--green-deep);
+  background: var(--canvas);
+  animation: card-in 180ms ease-out both;
+}
+
+.card:focus {
+  outline: none;
+}
+
+.header {
+  flex: 0 0 auto;
+  padding: 24px 64px 18px 32px;
+}
+
+.header h2 {
+  margin: 0 0 7px;
+  border: 0;
+  padding: 0;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 1.08rem;
+}
+
+.header p {
+  max-width: var(--measure);
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+/* One line that both counts the edit and teaches the two colours used below,
+   so the rows need no separate key. */
+.summary {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 10px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  margin: 0;
+  background: var(--canvas-soft);
+  padding: 10px 32px;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.places {
+  margin-right: 4px;
+  color: var(--ink);
+  font-weight: var(--w-strong);
+}
+
+.chip {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-weight: var(--w-strong);
+  white-space: nowrap;
+}
+
+.chipAdd {
+  border-color: color-mix(in srgb, var(--green) 35%, var(--canvas));
+  background: var(--green-soft);
+  color: var(--green-deep);
+}
+
+.chipRemove {
+  border-color: var(--warn-line-soft);
+  background: var(--warn-bg);
+  color: var(--warn-ink);
+}
+
+.body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 18px 32px 4px;
+}
+
+.notice {
+  margin: 0 0 16px;
+  border: 1px solid var(--line);
+  background: var(--canvas-soft);
+  padding: 14px 16px;
+  color: var(--muted);
+}
+
+.hunk {
+  margin: 0 0 16px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--canvas);
+}
+
+/* Where in the page this change sits. The nearest heading is the address a
+   contributor recognises; "@@ −41,7 +41,9 @@" is an address for a machine. */
+.hunkHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 4px 10px;
+  margin: 0;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--canvas-soft);
+  padding: 8px 12px;
+  font-size: 0.82rem;
+}
+
+.hunkIndex {
+  flex: 0 0 auto;
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.hunkWhere {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-weight: var(--w-strong);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hunkWhere::before {
+  content: '';
+  display: inline-block;
+  width: 1px;
+  height: 0.8em;
+  margin-right: 10px;
+  background: var(--line);
+  vertical-align: -0.05em;
+}
+
+.rows {
+  overflow-x: auto;
+}
+
+/* Two columns, not four: an accent edge with its sign, then the text. On a
+   360px phone the old twin line-number gutters cost a quarter of the width
+   and told a prose editor nothing. */
+/* No rule between rows. Hairlines turn continuous prose into a ledger; the
+   two washes already say where a change starts and stops. */
+.row {
+  display: grid;
+  grid-template-columns: 1.5rem minmax(0, 1fr);
+  min-width: 0;
+  border-left: 3px solid transparent;
+  line-height: 1.6;
+}
+
+/* An untouched blank line is a paragraph gap, not a line worth a whole row. */
+.blank .marker,
+.blank .code {
+  padding-top: 0;
+  padding-bottom: 0;
+  font-size: 0;
+  line-height: 8px;
+}
+
+.context {
+  color: var(--muted);
+}
+
+.addition {
+  border-left-color: var(--green);
+  background: var(--green-soft);
+}
+
+.deletion {
+  border-left-color: var(--warn-border);
+  background: var(--warn-bg);
+}
+
+.marker,
+.code {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+.marker {
+  color: var(--faint);
+  font-size: 0.85rem;
+  font-weight: var(--w-strong);
+  text-align: center;
+  user-select: none;
+}
+
+.addition .marker {
+  color: var(--green-deep);
+}
+
+.deletion .marker {
+  color: var(--warn-ink);
+}
+
+.code {
+  display: block;
+  padding-right: 12px;
+  font-family: var(--sans);
+  font-size: 1rem;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.addition .code,
+.deletion .code {
+  color: var(--ink);
+}
+
+.syntax {
+  color: var(--faint);
+}
+
+/* The point of the whole dialog: a one-word fix should read as one word, not
+   as two near-identical paragraphs to compare by eye. */
+.mark {
+  border-radius: 3px;
+  padding: 1px 1px;
+  color: var(--ink);
+  font-weight: var(--w-strong);
+}
+
+.addition .mark {
+  background: color-mix(in srgb, var(--green) 26%, var(--canvas));
+}
+
+.deletion .mark {
+  background: color-mix(in srgb, var(--warn-border) 48%, var(--canvas));
+}
+
+.footer {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid var(--line);
+  background: var(--canvas-soft);
+  padding: 12px 32px max(12px, env(safe-area-inset-bottom));
+}
+
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+@media (max-width: 640px) {
+  .card {
+    width: 100%;
+    max-height: calc(100vh - max(12px, env(safe-area-inset-top)));
+    max-height: calc(100dvh - max(12px, env(safe-area-inset-top)));
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    animation-name: sheet-in;
+    animation-duration: 220ms;
+  }
+
+  .header {
+    padding: 22px 60px 14px 18px;
+  }
+
+  .header p {
+    font-size: 1rem;
+  }
+
+  .summary {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .body {
+    padding: 14px 0 2px;
+  }
+
+  .notice,
+  .hunk {
+    margin-right: 18px;
+    margin-left: 18px;
+  }
+
+  .code {
+    padding-right: 10px;
+  }
+
+  .footer {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  /* Thumb-sized, and the send action keeps the right-hand edge it has in the
+     publish panel, so the primary button never changes sides. */
+  .footer :global(.edit-btn) {
+    flex: 1 1 0;
+    min-height: 44px;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    animation: none;
+  }
+}
+
+@keyframes sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+}

--- a/app/components/ContributionDiffDialog.tsx
+++ b/app/components/ContributionDiffDialog.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import React, { useEffect, useId, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import type { ContributionDiffRow, ContributionReview } from '../lib/contribution-diff'
+import styles from './ContributionDiffDialog.module.css'
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])'
+
+interface ContributionDiffDialogProps {
+  review: ContributionReview
+  isEn: boolean
+  onClose: () => void
+  /** Sending from here closes the dialog first, so errors land on the panel. */
+  onSubmit?: () => void
+  canSubmit?: boolean
+}
+
+function formatNumber(value: number, isEn: boolean): string {
+  return value.toLocaleString(isEn ? 'en-US' : 'bn-BD')
+}
+
+/**
+ * Heading hashes, bullets and quote marks at the head of a line. A contributor
+ * edited rendered prose and has never seen these, so they are dimmed rather
+ * than removed: the line stays honest, the sentence stays the loud part.
+ */
+const LEADING_SYNTAX = /^[ \t]*(?:#{1,6}[ \t]+|[-*+][ \t]+|\d+[.)][ \t]+|>[ \t]?)+/
+
+/**
+ * The line as the reader should see it: the words that actually moved carry a
+ * mark, and everything else stays plain. Lines with no pairing fall back to
+ * one flat run, which the row tint already colours.
+ */
+function RowText({ row }: { row: ContributionDiffRow }) {
+  const segments = row.segments ?? [{ kind: 'same' as const, text: row.text }]
+  const prefix = row.text.match(LEADING_SYNTAX)?.[0] ?? ''
+  // Only lift the prefix when it sits wholly inside the first unchanged run,
+  // otherwise a word mark that starts mid-prefix would be split in half.
+  const lifted =
+    prefix && segments[0].kind === 'same' && segments[0].text.length >= prefix.length
+      ? prefix
+      : ''
+
+  return (
+    <>
+      {lifted && <span className={styles.syntax}>{lifted}</span>}
+      {segments.map((segment, index) => {
+        const text = index === 0 ? segment.text.slice(lifted.length) : segment.text
+        if (text === '') return null
+        return segment.kind === 'changed' ? (
+          <mark className={styles.mark} key={index}>
+            {text}
+          </mark>
+        ) : (
+          <React.Fragment key={index}>{text}</React.Fragment>
+        )
+      })}
+    </>
+  )
+}
+
+export default function ContributionDiffDialog({
+  review,
+  isEn,
+  onClose,
+  onSubmit,
+  canSubmit = false
+}: ContributionDiffDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  const headingId = useId()
+  const descriptionId = useId()
+  const summaryId = useId()
+  const t = (bn: string, en: string) => (isEn ? en : bn)
+
+  useEffect(() => {
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    const background = Array.from(document.body.children).filter(
+      (element): element is HTMLElement =>
+        element instanceof HTMLElement &&
+        !element.hasAttribute('data-contribution-review-portal')
+    )
+    const previousInert = background.map((element) => element.inert)
+    background.forEach((element) => {
+      element.inert = true
+    })
+
+    const focusFrame = window.requestAnimationFrame(() => dialogRef.current?.focus())
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+        return
+      }
+      if (event.key !== 'Tab' || !dialogRef.current) return
+
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((element) => !element.hidden && element.getAttribute('aria-hidden') !== 'true')
+      if (focusable.length === 0) {
+        event.preventDefault()
+        dialogRef.current.focus()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (
+        document.activeElement === dialogRef.current ||
+        !dialogRef.current.contains(document.activeElement)
+      ) {
+        event.preventDefault()
+        ;(event.shiftKey ? last : first).focus()
+      } else if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.cancelAnimationFrame(focusFrame)
+      document.removeEventListener('keydown', handleKeyDown)
+      background.forEach((element, index) => {
+        element.inert = previousInert[index]
+      })
+      document.body.style.overflow = previousOverflow
+      window.requestAnimationFrame(() => previousFocusRef.current?.focus())
+    }
+  }, [onClose])
+
+  const places = review.hunks.length
+
+  return createPortal(
+    <div
+      className="modal-overlay"
+      data-contribution-review-portal
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div
+        className={styles.card}
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        aria-describedby={
+          review.status === 'ready' ? `${descriptionId} ${summaryId}` : descriptionId
+        }
+        tabIndex={-1}
+      >
+        <header className={styles.header}>
+          <button
+            className="modal-close"
+            type="button"
+            aria-label={t('এডিটে ফিরুন', 'Close change review')}
+            onClick={onClose}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m6 6 12 12M18 6 6 18" />
+            </svg>
+          </button>
+          <h2 id={headingId}>{t('এডিটে কী বদলেছে', 'Review changes')}</h2>
+          <p id={descriptionId}>
+            {t(
+              'রিভিউতে পাঠানোর আগে যোগ ও বাদ দেওয়া অংশ দেখে নিন।',
+              'Check what was added or removed before sending it for review.'
+            )}
+          </p>
+        </header>
+
+        {review.status === 'ready' && (
+          /* The chips are the legend: each count is painted in the colour the
+             rows below use, so nothing has to explain green and amber twice. */
+          <p className={styles.summary} id={summaryId}>
+            <span className={styles.places}>
+              {isEn
+                ? `${formatNumber(places, true)} ${places === 1 ? 'place' : 'places'} changed`
+                : `${formatNumber(places, false)} জায়গায় বদল`}
+            </span>
+            <span className={`${styles.chip} ${styles.chipAdd}`}>
+              {isEn
+                ? `+${formatNumber(review.additions, true)} added`
+                : `+${formatNumber(review.additions, false)} যোগ`}
+            </span>
+            <span className={`${styles.chip} ${styles.chipRemove}`}>
+              {isEn
+                ? `−${formatNumber(review.deletions, true)} removed`
+                : `−${formatNumber(review.deletions, false)} বাদ`}
+            </span>
+          </p>
+        )}
+
+        <div className={styles.body}>
+          {review.status === 'too-large' ? (
+            <p className={styles.notice}>
+              {t(
+                'এডিটটি এখানে দেখানোর জন্য খুব বড়, তাই পাঠানোর আগে লেখাটি একবার দেখে নিন।',
+                'This edit is too large to preview here, so check the article once before sending it.'
+              )}
+            </p>
+          ) : review.status === 'unchanged' ? (
+            <p className={styles.notice}>
+              {t(
+                'লেখায় কিছু বদলায়নি, ছবির তথ্য উপরের তালিকায় আছে।',
+                'No text changed; image details remain in the editor above.'
+              )}
+            </p>
+          ) : (
+            review.hunks.map((hunk, hunkIndex) => {
+              const position = isEn
+                ? `Change ${formatNumber(hunkIndex + 1, true)} of ${formatNumber(places, true)}`
+                : `পরিবর্তন ${formatNumber(hunkIndex + 1, false)}/${formatNumber(places, false)}`
+              return (
+                <section
+                  className={styles.hunk}
+                  key={`${hunk.oldStart}-${hunk.newStart}-${hunkIndex}`}
+                  aria-label={hunk.heading ? `${position}, ${hunk.heading}` : position}
+                >
+                  <p className={styles.hunkHeader} aria-hidden="true">
+                    <span className={styles.hunkIndex}>{position}</span>
+                    {hunk.heading && (
+                      <span className={styles.hunkWhere} title={hunk.heading}>
+                        {hunk.heading}
+                      </span>
+                    )}
+                  </p>
+                  <div className={styles.rows}>
+                    {hunk.rows
+                      .filter((row) => !row.wrapper)
+                      .map((row, rowIndex) => (
+                        <div
+                          className={`${styles.row} ${styles[row.kind]}${
+                            row.kind === 'context' && row.text === '' ? ` ${styles.blank}` : ''
+                          }`}
+                          key={`${row.kind}-${row.oldLine}-${row.newLine}-${rowIndex}`}
+                        >
+                          <span className={styles.marker} aria-hidden="true">
+                            {row.kind === 'addition' ? '+' : row.kind === 'deletion' ? '−' : ''}
+                          </span>
+                          <span className={styles.code}>
+                            {row.kind !== 'context' && (
+                              <span className="sr-only">
+                                {row.kind === 'addition'
+                                  ? t('যোগ করা হয়েছে: ', 'Added: ')
+                                  : t('বাদ দেওয়া হয়েছে: ', 'Removed: ')}
+                              </span>
+                            )}
+                            {row.text ? (
+                              <RowText row={row} />
+                            ) : (
+                              <>
+                                <span className="sr-only">{t('ফাঁকা লাইন', 'blank line')}</span>
+                                <span aria-hidden="true">&nbsp;</span>
+                              </>
+                            )}
+                          </span>
+                        </div>
+                      ))}
+                  </div>
+                </section>
+              )
+            })
+          )}
+        </div>
+
+        <footer className={styles.footer}>
+          <button type="button" className="edit-btn" onClick={onClose}>
+            {t('এডিটে ফিরুন', 'Back to editing')}
+          </button>
+          {onSubmit && (
+            <button
+              type="button"
+              className="edit-btn is-primary"
+              onClick={onSubmit}
+              disabled={!canSubmit}
+            >
+              {t('রিভিউতে পাঠান', 'Send for review')}
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/app/components/ContributionEditor.tsx
+++ b/app/components/ContributionEditor.tsx
@@ -38,6 +38,9 @@ import {
   extractPendingMediaIds,
   rejectPendingMediaInMarkdown
 } from '../lib/contribution-media'
+import { buildContributionReview } from '../lib/contribution-diff'
+import type { ContributionReview } from '../lib/contribution-diff'
+import ContributionDiffDialog from './ContributionDiffDialog'
 
 /**
  * DIRECTION CONTRACT
@@ -207,10 +210,12 @@ export default function ContributionEditor({
   const [pendingMedia, setPendingMedia] = useState<PendingMedia[]>([])
   const [uploadingImage, setUploadingImage] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
+  const [review, setReview] = useState<ContributionReview | null>(null)
   const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({})
   const containerRef = useRef<HTMLDivElement>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
   const summaryRef = useRef<HTMLTextAreaElement>(null)
+  const submitErrorRef = useRef<HTMLDivElement>(null)
   const crepeRef = useRef<Crepe | null>(null)
   const markdownRef = useRef<string>('')
   const baselineRef = useRef<string | null>(null)
@@ -611,6 +616,21 @@ export default function ContributionEditor({
   useEffect(() => onReadyChange(ready), [ready, onReadyChange])
   useEffect(() => onDirtyChange(dirty), [dirty, onDirtyChange])
 
+  // A submission can start from the sticky review sheet while the publish
+  // panel is far below the viewport. If validation or the network rejects it,
+  // take both sighted and keyboard users to the existing actionable error.
+  useEffect(() => {
+    if (!submitError) return undefined
+    const focusFrame = window.requestAnimationFrame(() => {
+      const errorNode = submitErrorRef.current
+      // Reauthentication owns focus when its modal is open.
+      if (!errorNode || errorNode.closest('[inert]')) return
+      errorNode.scrollIntoView({ block: 'center' })
+      errorNode.focus({ preventScroll: true })
+    })
+    return () => window.cancelAnimationFrame(focusFrame)
+  }, [submitError])
+
   // The shell asks to leave (browser back). Never drop work silently.
   // Edge-triggered, not level-triggered: the counter lives in the shell and
   // keeps climbing across edit sessions, so a fresh editor must react to the
@@ -823,6 +843,21 @@ export default function ContributionEditor({
     }
   }
 
+  const closeReview = useCallback(() => setReview(null), [])
+
+  function openReview() {
+    if (baselineRef.current === null) return
+    let current = markdownRef.current
+    try {
+      current = readMarkdown(crepeRef.current)
+    } catch {
+      // markdownRef follows every successful editor serialization, so it is a
+      // safe last-known copy if Crepe is briefly between transactions.
+    }
+    markdownRef.current = current
+    setReview(buildContributionReview(baselineRef.current, current))
+  }
+
   const ghEditUrl = `${REPO_URL}/edit/main/${repoFileFor(pathname)}`
   const pageTitle = data?.frontmatter.title || data?.title || fallbackTitle
 
@@ -902,19 +937,38 @@ export default function ContributionEditor({
                 {error ? t(isEn, 'পড়ায় ফিরুন', 'Back to reading') : t(isEn, 'বাতিল', 'Cancel')}
               </button>
               {!error && (
-                <button
-                  type="button"
-                  className="edit-btn is-primary"
-                  onClick={handleSubmit}
-                  disabled={!ready || !dirty || submitting}
-                  title={
-                    ready && !dirty
-                      ? t(isEn, 'এখনো কিছু বদলাননি।', 'Nothing has changed yet.')
-                      : undefined
-                  }
-                >
-                  {t(isEn, 'রিভিউতে পাঠান', 'Send for review')}
-                </button>
+                <>
+                  {/* Always present, disabled while clean: a control that
+                      appears on the first keystroke pushes the primary button
+                      sideways under the reader's own cursor. */}
+                  <button
+                    type="button"
+                    className="edit-btn edit-btn--review"
+                    aria-haspopup="dialog"
+                    onClick={openReview}
+                    disabled={!ready || !dirty || submitting}
+                    title={
+                      ready && !dirty
+                        ? t(isEn, 'এখনো কিছু বদলাননি।', 'Nothing has changed yet.')
+                        : undefined
+                    }
+                  >
+                    {t(isEn, 'কী বদলেছে', 'Review changes')}
+                  </button>
+                  <button
+                    type="button"
+                    className="edit-btn is-primary edit-btn--send"
+                    onClick={handleSubmit}
+                    disabled={!ready || !dirty || submitting}
+                    title={
+                      ready && !dirty
+                        ? t(isEn, 'এখনো কিছু বদলাননি।', 'Nothing has changed yet.')
+                        : undefined
+                    }
+                  >
+                    {t(isEn, 'রিভিউতে পাঠান', 'Send for review')}
+                  </button>
+                </>
               )}
             </>
           )}
@@ -1257,7 +1311,12 @@ export default function ContributionEditor({
             />
 
             {submitError && (
-              <div className="edit-publish__error" role="alert">
+              <div
+                className="edit-publish__error"
+                ref={submitErrorRef}
+                role="alert"
+                tabIndex={-1}
+              >
                 <p>
                   {submitError === 'unauthorized'
                     ? t(
@@ -1372,6 +1431,15 @@ export default function ContributionEditor({
                 </button>
                 <button
                   type="button"
+                  className="edit-btn"
+                  aria-haspopup="dialog"
+                  onClick={openReview}
+                  disabled={!ready || !dirty || submitting}
+                >
+                  {t(isEn, 'কী বদলেছে', 'Review changes')}
+                </button>
+                <button
+                  type="button"
                   className="edit-btn is-primary"
                   onClick={handleSubmit}
                   disabled={!ready || !dirty || submitting}
@@ -1384,6 +1452,20 @@ export default function ContributionEditor({
             </div>
           </div>
         </>
+      )}
+      {review && (
+        <ContributionDiffDialog
+          review={review}
+          isEn={isEn}
+          onClose={closeReview}
+          // Close first: a submit error belongs on the publish panel, which
+          // this sheet would otherwise be covering.
+          onSubmit={() => {
+            closeReview()
+            void handleSubmit()
+          }}
+          canSubmit={ready && dirty && !submitting}
+        />
       )}
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -4488,6 +4488,11 @@ body.auth-open {
   font-size: 0.9rem;
 }
 
+.edit-publish__error:focus {
+  outline: 2px solid var(--green-deep);
+  outline-offset: 2px;
+}
+
 .edit-publish__error p {
   margin: 0;
 }
@@ -4869,9 +4874,9 @@ body.auth-open {
     padding: 10px 18px;
   }
 
-  /* One row while nothing is at stake: page name on the left, the two actions on
-     the right. The status line only claims a second row once there is something
-     to say, which on a 714px-tall phone is a row worth not spending. */
+  /* At compact tablet widths the page name and available actions share the
+     first row when they fit. The status only claims another row once there is
+     something to say; the narrower phone rule below groups actions explicitly. */
   .edit-bar__what {
     flex: 1 1 8rem;
   }
@@ -4892,6 +4897,14 @@ body.auth-open {
 
   .edit-flash__close {
     width: 44px;
+  }
+
+  /* A phone cannot hold four thumb-sized actions on a sticky bar without
+     spending a third row of a 714px screen. So the bar keeps the step that
+     comes first — look at what changed — and sends from inside that sheet or
+     from the publish panel, the way a mobile wiki editor already works. */
+  .edit-bar__actions .edit-btn--send {
+    display: none;
   }
 
   .edit-live {
@@ -4976,6 +4989,36 @@ body.auth-open {
   .media-review__summary > a {
     flex-basis: 100%;
     margin-left: 0;
+  }
+
+  /* Keep the sticky editor at two rows across narrow phones: identity and
+     status share the first, while the three available actions divide the
+     second. A dirty-state message must not create a third persistent row. */
+  .edit-bar__status {
+    order: 0;
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 48%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .edit-bar__actions {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .edit-bar__actions .edit-btn {
+    flex: 1 1 0;
+    min-width: 0;
+    justify-content: center;
+    padding-inline: 8px;
+    text-align: center;
+  }
+
+  .edit-bar__actions .edit-bar__warn {
+    flex: 1 1 100%;
   }
 }
 

--- a/app/lib/contribution-diff.test.mjs
+++ b/app/lib/contribution-diff.test.mjs
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildContributionReview } from './contribution-diff.ts'
+import { encodeLockedMdx, normalizeContributionMarkdown } from './contribution-markdown.ts'
+
+test('returns no hunks when editor normalization makes the text equivalent', () => {
+  const compact = [
+    '| প্রশ্ন | ০ | ১ |',
+    '|---|---|---|',
+    '| সাম্প্রতিক ঘটনা শুনেছি? | না | একটা |',
+    ''
+  ].join('\n')
+  const padded = [
+    '| প্রশ্ন                  | ০      | ১    |',
+    '| ----------------------- | ------ | ---- |',
+    '| সাম্প্রতিক ঘটনা শুনেছি? | না     | একটা |',
+    ''
+  ].join('\n')
+
+  assert.deepEqual(
+    buildContributionReview(
+      normalizeContributionMarkdown(compact),
+      normalizeContributionMarkdown(padded)
+    ),
+    {
+      status: 'unchanged',
+      additions: 0,
+      deletions: 0,
+      hunks: []
+    }
+  )
+})
+
+test('reports additions and deletions with source line numbers', () => {
+  const before = ['# Title', '', '---', '', 'Old fee', 'Keep this', ''].join('\n')
+  const after = ['# Title', '', '---', '', 'New fee', 'Extra note', 'Keep this', ''].join('\n')
+  const review = buildContributionReview(before, after, { contextLines: 2 })
+
+  assert.equal(review.status, 'ready')
+  assert.equal(review.additions, 2)
+  assert.equal(review.deletions, 1)
+  assert.equal(review.hunks.length, 1)
+  assert.deepEqual(
+    review.hunks[0].rows
+      .filter((row) => row.kind !== 'context')
+      .map(({ kind, oldLine, newLine, text }) => ({ kind, oldLine, newLine, text })),
+    [
+      { kind: 'deletion', oldLine: 5, newLine: null, text: 'Old fee' },
+      { kind: 'addition', oldLine: null, newLine: 5, text: 'New fee' },
+      { kind: 'addition', oldLine: null, newLine: 6, text: 'Extra note' }
+    ]
+  )
+  assert.ok(
+    review.hunks[0].rows.some((row) => row.kind === 'context' && row.text === '---'),
+    'a Markdown thematic break should remain ordinary context'
+  )
+})
+
+test('collapses distant edits into separate compact hunks', () => {
+  const before = Array.from({ length: 30 }, (_, index) => `Line ${index + 1}`).join('\n')
+  const afterLines = before.split('\n')
+  afterLines[4] = 'Changed near the top'
+  afterLines[24] = 'Changed near the bottom'
+
+  const review = buildContributionReview(before, afterLines.join('\n'), { contextLines: 2 })
+
+  assert.equal(review.status, 'ready')
+  assert.equal(review.hunks.length, 2)
+  assert.ok(review.hunks.every((hunk) => hunk.rows.length <= 6))
+  assert.ok(review.hunks.every((hunk) => !hunk.rows.some((row) => row.text === 'Line 15')))
+})
+
+test('does not mark unchanged protected MDX as edited', () => {
+  const protectedBlock = '<StubNotice path="ideas/test" locale="en" />'
+  const before = encodeLockedMdx(['# Title', '', protectedBlock, '', 'Old copy', ''].join('\n'))
+  const after = encodeLockedMdx(['# Title', '', protectedBlock, '', 'New copy', ''].join('\n'))
+  const review = buildContributionReview(before, after)
+  const changedRows = review.hunks.flatMap((hunk) =>
+    hunk.rows.filter((row) => row.kind !== 'context')
+  )
+
+  assert.deepEqual(
+    changedRows.map(({ kind, text }) => ({ kind, text })),
+    [
+      { kind: 'deletion', text: 'Old copy' },
+      { kind: 'addition', text: 'New copy' }
+    ]
+  )
+})
+
+test('stops pathological comparisons at a fixed work budget', () => {
+  const before = Array.from({ length: 600 }, (_, index) => `Before ${index}`).join('\n')
+  const after = Array.from({ length: 600 }, (_, index) => `After ${index}`).join('\n')
+
+  assert.deepEqual(buildContributionReview(before, after, { maxWork: 200 }), {
+    status: 'too-large',
+    additions: 0,
+    deletions: 0,
+    hunks: []
+  })
+})
+
+test('rejects documents above the explicit line ceiling before diffing', () => {
+  const before = Array.from({ length: 21 }, (_, index) => `Line ${index}`).join('\n')
+  const after = `${before}\nOne more line`
+
+  assert.equal(buildContributionReview(before, after, { maxLines: 20 }).status, 'too-large')
+})
+
+test('bounds the number of changed rows the dialog could render', () => {
+  const after = Array.from({ length: 21 }, (_, index) => `Added ${index}`).join('\n')
+
+  assert.equal(
+    buildContributionReview('', after, { maxLines: 100, maxChangedLines: 20 }).status,
+    'too-large'
+  )
+})
+
+test('reconstructs both versions when lines repeat or move', () => {
+  for (const [before, after] of [
+    ['a\nb\na\nc', 'a\na\nb\nc'],
+    ['same\nend', 'start\nsame\nend\nlast'],
+    ['first\nrepeat\nrepeat\nlast', 'first\nrepeat\nlast']
+  ]) {
+    const review = buildContributionReview(before, after, { contextLines: 100 })
+    const rows = review.hunks.flatMap((hunk) => hunk.rows)
+    assert.equal(
+      rows
+        .filter((row) => row.kind !== 'addition')
+        .map((row) => row.text)
+        .join('\n'),
+      before
+    )
+    assert.equal(
+      rows
+        .filter((row) => row.kind !== 'deletion')
+        .map((row) => row.text)
+        .join('\n'),
+      after
+    )
+  }
+})
+
+test('marks only the words that moved inside a rewritten line', () => {
+  const before = ['# ফি', '', 'ট্রেড লাইসেন্সের ফি ২০২৪ সালে ছিল ১,০০০ টাকা।', ''].join('\n')
+  const after = ['# ফি', '', 'ট্রেড লাইসেন্সের ফি ২০২৬ সালে ছিল ১,০০০ টাকা।', ''].join('\n')
+  const rows = buildContributionReview(before, after).hunks.flatMap((hunk) => hunk.rows)
+  const removed = rows.find((row) => row.kind === 'deletion')
+  const added = rows.find((row) => row.kind === 'addition')
+
+  assert.deepEqual(
+    removed.segments.filter((segment) => segment.kind === 'changed').map((s) => s.text),
+    ['২০২৪']
+  )
+  assert.deepEqual(
+    added.segments.filter((segment) => segment.kind === 'changed').map((s) => s.text),
+    ['২০২৬']
+  )
+  for (const row of [removed, added]) {
+    assert.equal(row.segments.map((segment) => segment.text).join(''), row.text)
+  }
+})
+
+test('leaves a wholly different line without word marks', () => {
+  const review = buildContributionReview('Alpha beta gamma delta\n', 'একেবারে অন্য একটি বাক্য\n')
+  const rows = review.hunks.flatMap((hunk) => hunk.rows)
+
+  assert.ok(rows.some((row) => row.kind === 'deletion'))
+  assert.ok(rows.every((row) => row.segments === undefined))
+})
+
+test('does not pair a pure insertion with the line above it', () => {
+  const before = ['Keep this line', ''].join('\n')
+  const after = ['Keep this line', 'A brand new line', ''].join('\n')
+  const rows = buildContributionReview(before, after).hunks.flatMap((hunk) => hunk.rows)
+
+  assert.ok(rows.every((row) => row.segments === undefined))
+})
+
+test('names the nearest heading above each changed region', () => {
+  const before = [
+    '# শুরুর কথা',
+    '',
+    'প্রথম অনুচ্ছেদ।',
+    '',
+    '## **নবায়ন** করা',
+    '',
+    'দ্বিতীয় অনুচ্ছেদ।',
+    ''
+  ].join('\n')
+  const afterLines = before.split('\n')
+  afterLines[2] = 'প্রথম অনুচ্ছেদ বদলেছে।'
+  afterLines[6] = 'দ্বিতীয় অনুচ্ছেদ বদলেছে।'
+
+  const review = buildContributionReview(before, afterLines.join('\n'), { contextLines: 1 })
+  assert.deepEqual(
+    review.hunks.map((hunk) => hunk.heading),
+    ['শুরুর কথা', 'নবায়ন করা']
+  )
+})
+
+test('uses a nearby heading even when the context window opens above it', () => {
+  const before = ['# Intro', '', 'Opening copy.', '', '## Fees', '', 'Old fee', ''].join('\n')
+  const after = ['# Intro', '', 'Opening copy.', '', '## Fees', '', 'New fee', ''].join('\n')
+
+  const review = buildContributionReview(before, after)
+
+  assert.equal(review.hunks[0].heading, 'Fees')
+})
+
+test('does not use a heading that is itself being replaced', () => {
+  const review = buildContributionReview(
+    '# Intro\n\n## Old heading\n\nCopy\n',
+    '# Intro\n\n## New heading\n\nCopy\n'
+  )
+
+  assert.equal(review.hunks[0].heading, 'Intro')
+})
+
+test('reports no heading for a change that sits above the first one', () => {
+  const review = buildContributionReview('intro line\n\n# Later\n', 'edited line\n\n# Later\n', {
+    contextLines: 0
+  })
+
+  assert.equal(review.hunks[0].heading, null)
+})
+
+test('flags the protected-MDX fence so unchanged transport can be hidden', () => {
+  const block = '<StubNotice path="ideas/test" locale="bn" />'
+  const before = encodeLockedMdx(['# শিরোনাম', '', block, '', 'পুরনো লেখা।', ''].join('\n'))
+  const after = encodeLockedMdx(['# শিরোনাম', '', block, '', 'নতুন লেখা।', ''].join('\n'))
+  const rows = buildContributionReview(before, after, { contextLines: 4 }).hunks.flatMap(
+    (hunk) => hunk.rows
+  )
+
+  assert.deepEqual(
+    rows.filter((row) => row.wrapper).map((row) => row.text),
+    ['```deshi-locked-mdx', '```']
+  )
+  assert.ok(
+    rows.some((row) => row.text === block && !row.wrapper),
+    'the component itself stays visible as context'
+  )
+})

--- a/app/lib/contribution-diff.ts
+++ b/app/lib/contribution-diff.ts
@@ -1,0 +1,499 @@
+export type ContributionDiffKind = 'context' | 'addition' | 'deletion'
+
+/**
+ * One run inside a changed line. A prose edit is usually a couple of words in
+ * a long sentence, so the dialog needs to point at those words rather than
+ * hand the reader two near-identical paragraphs to compare by eye.
+ */
+export interface ContributionDiffSegment {
+  kind: 'same' | 'changed'
+  text: string
+}
+
+export interface ContributionDiffRow {
+  kind: ContributionDiffKind
+  oldLine: number | null
+  newLine: number | null
+  text: string
+  /** Present only when this line was paired with its counterpart. */
+  segments?: ContributionDiffSegment[]
+  /**
+   * A fence this editor wraps protected MDX in on the way through Crepe. It
+   * is transport, not the author's text, so an unchanged one is not shown.
+   */
+  wrapper?: boolean
+}
+
+export interface ContributionDiffHunk {
+  oldStart: number
+  oldCount: number
+  newStart: number
+  newCount: number
+  /** Nearest Markdown heading at or above this hunk, for "where am I". */
+  heading: string | null
+  rows: ContributionDiffRow[]
+}
+
+export interface ContributionReview {
+  status: 'unchanged' | 'ready' | 'too-large'
+  additions: number
+  deletions: number
+  hunks: ContributionDiffHunk[]
+}
+
+interface ContributionDiffOptions {
+  contextLines?: number
+  maxChangedLines?: number
+  maxLines?: number
+  maxWork?: number
+}
+
+interface RawDiffRow {
+  kind: 'equal' | 'addition' | 'deletion'
+  text: string
+}
+
+const DEFAULT_CONTEXT_LINES = 3
+const DEFAULT_MAX_CHANGED_LINES = 600
+const DEFAULT_MAX_LINES = 5_000
+const DEFAULT_MAX_WORK = 80_000
+/** A prose line is a few dozen tokens, so this budget is never reached in practice. */
+const WORD_MAX_WORK = 4_000
+/** Beyond this the pair is a rewrite, not an edit, and word marks only add noise. */
+const WORD_MIN_SHARED_RATIO = 0.25
+const WORD_MAX_LINE_LENGTH = 2_000
+const WORD_TOKENS = /[\p{L}\p{M}\p{N}_]+|\s+|[^\p{L}\p{M}\p{N}_\s]/gu
+const ATX_HEADING = /^ {0,3}(#{1,6})[ \t]+(.*?)(?:[ \t]+#+)?[ \t]*$/
+const LOCKED_FENCE_OPEN = '```deshi-locked-mdx'
+const LOCKED_FENCE_CLOSE = '```'
+
+function integerOption(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && value !== undefined && value >= 0
+    ? Math.floor(value)
+    : fallback
+}
+
+function linesOf(markdown: string): string[] {
+  return markdown === '' ? [] : markdown.split('\n')
+}
+
+function mapValue(map: Map<number, number>, key: number): number {
+  return map.get(key) ?? -1
+}
+
+/** Reconstruct Myers' shortest edit script from the saved frontiers. */
+function backtrack(
+  trace: Map<number, number>[],
+  before: string[],
+  after: string[]
+): RawDiffRow[] {
+  let x = before.length
+  let y = after.length
+  const reversed: RawDiffRow[] = []
+
+  for (let depth = trace.length - 1; depth >= 0; depth -= 1) {
+    const frontier = trace[depth]
+    const diagonal = x - y
+    const previousDiagonal =
+      diagonal === -depth ||
+      (diagonal !== depth && mapValue(frontier, diagonal - 1) < mapValue(frontier, diagonal + 1))
+        ? diagonal + 1
+        : diagonal - 1
+    const previousX = Math.max(0, mapValue(frontier, previousDiagonal))
+    const previousY = previousX - previousDiagonal
+
+    while (x > previousX && y > previousY) {
+      reversed.push({ kind: 'equal', text: before[x - 1] })
+      x -= 1
+      y -= 1
+    }
+
+    if (depth === 0) break
+    if (x === previousX) {
+      reversed.push({ kind: 'addition', text: after[y - 1] })
+      y -= 1
+    } else {
+      reversed.push({ kind: 'deletion', text: before[x - 1] })
+      x -= 1
+    }
+  }
+
+  return reversed.reverse()
+}
+
+/**
+ * Myers line diff with an explicit work ceiling. The normal case is a small
+ * edit to a guide and finishes near-linearly; adversarial replacements stop
+ * at the budget instead of allocating an N x M matrix on the reader's phone.
+ */
+function diffMiddle(
+  before: string[],
+  after: string[],
+  maxWork: number,
+  maxChangedLines: number
+): RawDiffRow[] | null {
+  if (before.length === 0) {
+    return after.length > maxChangedLines
+      ? null
+      : after.map((text) => ({ kind: 'addition', text }))
+  }
+  if (after.length === 0) {
+    return before.length > maxChangedLines
+      ? null
+      : before.map((text) => ({ kind: 'deletion', text }))
+  }
+
+  const maximumDepth = Math.min(before.length + after.length, maxChangedLines)
+  const frontier = new Map<number, number>([[1, 0]])
+  const trace: Map<number, number>[] = []
+  let work = 0
+
+  for (let depth = 0; depth <= maximumDepth; depth += 1) {
+    trace.push(new Map(frontier))
+
+    for (let diagonal = -depth; diagonal <= depth; diagonal += 2) {
+      work += 1
+      if (work > maxWork) return null
+
+      let x
+      if (
+        diagonal === -depth ||
+        (diagonal !== depth &&
+          mapValue(frontier, diagonal - 1) < mapValue(frontier, diagonal + 1))
+      ) {
+        x = Math.max(0, mapValue(frontier, diagonal + 1))
+      } else {
+        x = mapValue(frontier, diagonal - 1) + 1
+      }
+      let y = x - diagonal
+
+      while (x < before.length && y < after.length && before[x] === after[y]) {
+        x += 1
+        y += 1
+        work += 1
+        if (work > maxWork) return null
+      }
+
+      frontier.set(diagonal, x)
+      if (x >= before.length && y >= after.length) {
+        return backtrack(trace, before, after)
+      }
+    }
+  }
+
+  return null
+}
+
+function numberedRows(rows: RawDiffRow[]): ContributionDiffRow[] {
+  let oldLine = 1
+  let newLine = 1
+
+  return rows.map((row) => {
+    if (row.kind === 'equal') {
+      const numbered = {
+        kind: 'context' as const,
+        oldLine,
+        newLine,
+        text: row.text
+      }
+      oldLine += 1
+      newLine += 1
+      return numbered
+    }
+    if (row.kind === 'deletion') {
+      const numbered = {
+        kind: 'deletion' as const,
+        oldLine,
+        newLine: null,
+        text: row.text
+      }
+      oldLine += 1
+      return numbered
+    }
+    const numbered = {
+      kind: 'addition' as const,
+      oldLine: null,
+      newLine,
+      text: row.text
+    }
+    newLine += 1
+    return numbered
+  })
+}
+
+function tokenize(line: string): string[] {
+  return line.match(WORD_TOKENS) ?? []
+}
+
+/** Adjacent runs of one kind become one span, and a lone gap of whitespace
+    between two changes is absorbed so a two-word fix reads as one mark. */
+function coalesce(segments: ContributionDiffSegment[]): ContributionDiffSegment[] {
+  const merged: ContributionDiffSegment[] = []
+  for (const segment of segments) {
+    if (segment.text === '') continue
+    const previous = merged.at(-1)
+    if (previous && previous.kind === segment.kind) previous.text += segment.text
+    else merged.push({ ...segment })
+  }
+
+  const bridged: ContributionDiffSegment[] = []
+  for (let index = 0; index < merged.length; index += 1) {
+    const segment = merged[index]
+    const isWhitespaceGap =
+      segment.kind === 'same' &&
+      segment.text.trim() === '' &&
+      index > 0 &&
+      index < merged.length - 1
+    if (isWhitespaceGap) bridged.push({ kind: 'changed', text: segment.text })
+    else bridged.push(segment)
+  }
+
+  const finished: ContributionDiffSegment[] = []
+  for (const segment of bridged) {
+    const previous = finished.at(-1)
+    if (previous && previous.kind === segment.kind) previous.text += segment.text
+    else finished.push({ ...segment })
+  }
+  return finished
+}
+
+/**
+ * Mark the words that actually moved between one removed line and the added
+ * line that replaced it. Returns null when the two lines share too little to
+ * be the same sentence, in which case the whole line stays marked instead.
+ */
+function pairSegments(
+  before: string,
+  after: string
+): { before: ContributionDiffSegment[]; after: ContributionDiffSegment[] } | null {
+  if (before.length > WORD_MAX_LINE_LENGTH || after.length > WORD_MAX_LINE_LENGTH) return null
+
+  const beforeTokens = tokenize(before)
+  const afterTokens = tokenize(after)
+  if (beforeTokens.length === 0 || afterTokens.length === 0) return null
+
+  const raw = diffMiddle(
+    beforeTokens,
+    afterTokens,
+    WORD_MAX_WORK,
+    beforeTokens.length + afterTokens.length
+  )
+  if (!raw) return null
+
+  const shared = raw.reduce(
+    (total, row) => (row.kind === 'equal' ? total + row.text.trim().length : total),
+    0
+  )
+  const longest = Math.max(before.trim().length, after.trim().length, 1)
+  if (shared / longest < WORD_MIN_SHARED_RATIO) return null
+
+  return {
+    before: coalesce(
+      raw.flatMap((row) =>
+        row.kind === 'addition'
+          ? []
+          : [{ kind: row.kind === 'equal' ? ('same' as const) : ('changed' as const), text: row.text }]
+      )
+    ),
+    after: coalesce(
+      raw.flatMap((row) =>
+        row.kind === 'deletion'
+          ? []
+          : [{ kind: row.kind === 'equal' ? ('same' as const) : ('changed' as const), text: row.text }]
+      )
+    )
+  }
+}
+
+/**
+ * A removed line immediately followed by an added line is nearly always the
+ * same sentence, edited. Pair those runs off so each half can carry its word
+ * marks; the leftovers of an uneven run stay whole-line changes.
+ */
+function markWordChanges(rows: ContributionDiffRow[]): void {
+  let index = 0
+  while (index < rows.length) {
+    if (rows[index].kind !== 'deletion') {
+      index += 1
+      continue
+    }
+    let deletionEnd = index
+    while (deletionEnd < rows.length && rows[deletionEnd].kind === 'deletion') deletionEnd += 1
+    let additionEnd = deletionEnd
+    while (additionEnd < rows.length && rows[additionEnd].kind === 'addition') additionEnd += 1
+
+    const pairs = Math.min(deletionEnd - index, additionEnd - deletionEnd)
+    for (let offset = 0; offset < pairs; offset += 1) {
+      const removed = rows[index + offset]
+      const added = rows[deletionEnd + offset]
+      const segments = pairSegments(removed.text, added.text)
+      if (!segments) continue
+      removed.segments = segments.before
+      added.segments = segments.after
+    }
+    index = additionEnd > index ? additionEnd : index + 1
+  }
+}
+
+/**
+ * Flag the fence pair around protected MDX so the dialog can leave it out of
+ * the context it shows. A contributor never typed ```deshi-locked-mdx and
+ * cannot change what is inside it, so an unchanged fence is only noise.
+ */
+function markLockedFences(rows: ContributionDiffRow[]): void {
+  for (let index = 0; index < rows.length; index += 1) {
+    if (rows[index].kind !== 'context' || rows[index].text !== LOCKED_FENCE_OPEN) continue
+    for (let cursor = index + 1; cursor < rows.length; cursor += 1) {
+      if (rows[cursor].text === LOCKED_FENCE_OPEN) break
+      if (rows[cursor].kind === 'context' && rows[cursor].text === LOCKED_FENCE_CLOSE) {
+        rows[index].wrapper = true
+        rows[cursor].wrapper = true
+        index = cursor
+        break
+      }
+    }
+  }
+}
+
+/** Strip the inline Markdown a heading may carry, so the label reads as prose. */
+function plainHeading(text: string): string {
+  return text
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[*_~`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** For every row, the nearest heading at or above it in the edited document. */
+function headingTrail(rows: ContributionDiffRow[]): Array<string | null> {
+  const trail: Array<string | null> = []
+  let current: string | null = null
+  for (const row of rows) {
+    const match = row.kind === 'deletion' ? null : row.text.match(ATX_HEADING)
+    if (match) current = plainHeading(match[2]) || null
+    trail.push(current)
+  }
+  return trail
+}
+
+function hunkFrom(rows: ContributionDiffRow[], heading: string | null): ContributionDiffHunk {
+  const oldLines = rows.flatMap((row) => (row.oldLine === null ? [] : [row.oldLine]))
+  const newLines = rows.flatMap((row) => (row.newLine === null ? [] : [row.newLine]))
+  return {
+    oldStart: oldLines[0] ?? 0,
+    oldCount: oldLines.length,
+    newStart: newLines[0] ?? 0,
+    newCount: newLines.length,
+    heading,
+    rows
+  }
+}
+
+function compactHunks(rows: ContributionDiffRow[], contextLines: number): ContributionDiffHunk[] {
+  const changed = rows.flatMap((row, index) => (row.kind === 'context' ? [] : [index]))
+  if (changed.length === 0) return []
+
+  const windows: Array<{ start: number; end: number }> = []
+  for (const index of changed) {
+    const start = Math.max(0, index - contextLines)
+    const end = Math.min(rows.length, index + contextLines + 1)
+    const previous = windows.at(-1)
+    if (previous && start <= previous.end) previous.end = Math.max(previous.end, end)
+    else windows.push({ start, end })
+  }
+
+  const trail = headingTrail(rows)
+  return windows.map(({ start, end }) => {
+    const hunkRows = rows.slice(start, end)
+    const firstChangedOffset = hunkRows.findIndex((row) => row.kind !== 'context')
+    const rowBeforeChange = start + firstChangedOffset - 1
+    // Resolve from the change, not from the context window: that window often
+    // opens above the nearby heading. Looking one row back also means a heading
+    // that is itself added or replaced does not misleadingly name its own hunk.
+    const heading = rowBeforeChange >= 0 ? trail[rowBeforeChange] : null
+    return hunkFrom(hunkRows, heading)
+  })
+}
+
+const EMPTY_REVIEW: ContributionReview = {
+  status: 'unchanged',
+  additions: 0,
+  deletions: 0,
+  hunks: []
+}
+
+const TOO_LARGE_REVIEW: ContributionReview = {
+  status: 'too-large',
+  additions: 0,
+  deletions: 0,
+  hunks: []
+}
+
+/**
+ * Compare the normalized strings already used for dirty tracking and submit.
+ * The result contains only changed regions plus a small amount of context.
+ */
+export function buildContributionReview(
+  beforeMarkdown: string,
+  afterMarkdown: string,
+  options: ContributionDiffOptions = {}
+): ContributionReview {
+  if (beforeMarkdown === afterMarkdown) return { ...EMPTY_REVIEW }
+
+  const contextLines = integerOption(options.contextLines, DEFAULT_CONTEXT_LINES)
+  const maxChangedLines = integerOption(
+    options.maxChangedLines,
+    DEFAULT_MAX_CHANGED_LINES
+  )
+  const maxLines = integerOption(options.maxLines, DEFAULT_MAX_LINES)
+  const maxWork = integerOption(options.maxWork, DEFAULT_MAX_WORK)
+  const before = linesOf(beforeMarkdown)
+  const after = linesOf(afterMarkdown)
+  if (before.length > maxLines || after.length > maxLines) return { ...TOO_LARGE_REVIEW }
+
+  let prefixLength = 0
+  while (
+    prefixLength < before.length &&
+    prefixLength < after.length &&
+    before[prefixLength] === after[prefixLength]
+  ) {
+    prefixLength += 1
+  }
+
+  let suffixLength = 0
+  while (
+    suffixLength < before.length - prefixLength &&
+    suffixLength < after.length - prefixLength &&
+    before[before.length - suffixLength - 1] === after[after.length - suffixLength - 1]
+  ) {
+    suffixLength += 1
+  }
+
+  const middle = diffMiddle(
+    before.slice(prefixLength, before.length - suffixLength),
+    after.slice(prefixLength, after.length - suffixLength),
+    maxWork,
+    maxChangedLines
+  )
+  if (!middle) return { ...TOO_LARGE_REVIEW }
+
+  const rawRows: RawDiffRow[] = [
+    ...before.slice(0, prefixLength).map((text) => ({ kind: 'equal' as const, text })),
+    ...middle,
+    ...before
+      .slice(before.length - suffixLength)
+      .map((text) => ({ kind: 'equal' as const, text }))
+  ]
+  const rows = numberedRows(rawRows)
+  markWordChanges(rows)
+  markLockedFences(rows)
+  const additions = rows.filter((row) => row.kind === 'addition').length
+  const deletions = rows.filter((row) => row.kind === 'deletion').length
+
+  return {
+    status: additions || deletions ? 'ready' : 'unchanged',
+    additions,
+    deletions,
+    hunks: compactHunks(rows, contextLines)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint:bangla": "node scripts/bangla-lint.mjs",
     "lint:routes": "node scripts/route-lint.mjs",
     "lint:terms": "node scripts/apply-terms.mjs",
-    "test:contribute": "node --experimental-strip-types --test app/lib/contributable-path.test.mjs app/lib/contribution-markdown.test.mjs app/lib/contribution-draft.test.mjs app/lib/contribution-media.test.mjs app/lib/clean-route.test.mjs app/lib/page-chrome.test.mjs",
+    "test:contribute": "node --experimental-strip-types --test app/lib/contributable-path.test.mjs app/lib/contribution-markdown.test.mjs app/lib/contribution-diff.test.mjs app/lib/contribution-draft.test.mjs app/lib/contribution-media.test.mjs app/lib/clean-route.test.mjs app/lib/page-chrome.test.mjs",
     "test:contributors": "node --test scripts/contributor-data.test.mjs scripts/contributor-cards.test.mjs scripts/content-guide.test.mjs scripts/postbuild-contributors.test.mjs app/lib/contributor-event-locale.test.mjs app/lib/contributor-leaderboard.test.mjs app/lib/contributor-topics.test.mjs app/lib/page-byline.test.mjs app/lib/page-credits.test.mjs",
     "test:analytics": "node --experimental-strip-types --test app/lib/search-analytics.test.mjs",
     "search:audit": "node scripts/search-audit.mjs",


### PR DESCRIPTION
## What this ships

- Adds an on-demand review step to the browser editor before submission.
- Shows readable, single-column diffs with word-level highlighting and section context.
- Keeps the review usable on narrow mobile screens without line-number gutters or raw diff syntax.
- Preserves the lightweight reading path: the diff code loads only when a contributor opens the editor.

## Scope

This replaces the earlier dashboard and contribution-retrieval proposal with the focused part we want to ship: helping contributors understand exactly what they changed before sending it for review.

## Credit

This remains Anwarul Islam's pull request and builds on the original proposal by @anwarulislam. The replacement commit also records Anwar as a co-author.

## Verification

- Contribution helper tests pass
- TypeScript check passes
- Production build passes
- Responsive review completed at phone and desktop widths
