### PR TITLE
Stabilize static routes and development builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 out/
 .next/
+# `next dev` builds here instead, so a dev server running in an editor cannot
+# corrupt a production build's .next. See next.config.mjs.
+.next-dev/
 _pagefind/
 *.log
 .env

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { usePathname, useRouter } from 'next/navigation'
+import { cleanRoute } from '../lib/clean-route'
 
 /**
  * Real, crawlable link between the Bengali and English mirrors. The click
@@ -9,7 +10,9 @@ import { usePathname, useRouter } from 'next/navigation'
  * plain <a href> still works for users and crawlers.
  */
 export default function LanguageSwitcher() {
-  const pathname = usePathname()
+  // Clean spelling, or /en.html reads as the Bengali side and this links to
+  // /en/en.html. See app/lib/clean-route.ts.
+  const pathname = cleanRoute(usePathname())
   const router = useRouter()
   const isEn = pathname.startsWith('/en/') || pathname === '/en'
   // One 404 document serves every unmatched URL, so the router reports the

--- a/app/components/LocalizedLayout.tsx
+++ b/app/components/LocalizedLayout.tsx
@@ -7,6 +7,7 @@ import LanguageSwitcher from './LanguageSwitcher'
 import SearchBox from './SearchBox'
 import AuthModal from './AuthModal'
 import type { SubmitResult } from './ContributionEditor'
+import { cleanRoute } from '../lib/clean-route'
 import { clearAuth, getStoredAuth, UserInfo } from '../lib/client-auth'
 import {
   bnNav,
@@ -216,7 +217,7 @@ interface LocalizedLayoutProps {
 }
 
 export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
-  const pathname = usePathname()
+  const pathname = cleanRoute(usePathname())
   const isEn = pathname.startsWith('/en/') || pathname === '/en'
   const isLanding = pathname === '/' || pathname === '/en'
   const isPrivateReview =

--- a/app/lib/clean-route.test.mjs
+++ b/app/lib/clean-route.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { cleanRoute } from './clean-route.ts'
+
+test('clean URLs are returned unchanged', () => {
+  assert.equal(cleanRoute('/'), '/')
+  assert.equal(cleanRoute('/en'), '/en')
+  assert.equal(cleanRoute('/en/start-here'), '/en/start-here')
+  assert.equal(cleanRoute('/registration/structure-comparison'), '/registration/structure-comparison')
+})
+
+test('the literal exported file name resolves to its clean route', () => {
+  assert.equal(cleanRoute('/en.html'), '/en')
+  assert.equal(cleanRoute('/en/start-here.html'), '/en/start-here')
+  assert.equal(cleanRoute('/index.html'), '/')
+  assert.equal(cleanRoute('/en/index.html'), '/en')
+})
+
+test('a trailing slash is an equivalent spelling', () => {
+  assert.equal(cleanRoute('/en/'), '/en')
+  assert.equal(cleanRoute('/registration/'), '/registration')
+})
+
+test('the English test holds for every spelling of the English home', () => {
+  const isEn = (path) => {
+    const route = cleanRoute(path)
+    return route === '/en' || route.startsWith('/en/')
+  }
+  for (const spelling of ['/en', '/en/', '/en.html', '/en/index.html']) {
+    assert.equal(isEn(spelling), true, spelling)
+  }
+  for (const spelling of ['/', '/index.html', '/enterprise', '/english']) {
+    assert.equal(isEn(spelling), false, spelling)
+  }
+})

--- a/app/lib/clean-route.ts
+++ b/app/lib/clean-route.ts
@@ -1,0 +1,22 @@
+/**
+ * The clean spelling of the route the reader is on.
+ *
+ * `output: 'export'` writes real files, and a static host serves them at their
+ * literal names as well as at the clean URL — the GitHub Pages mirror answers
+ * `/en.html` and `/en/start-here.html` directly, with no redirect to `/en`.
+ * Every route comparison in the shell (`isEn`, `isLanding`, the breadcrumb
+ * split, the source-file path) is written against the clean spelling, so a
+ * reader who lands on the literal name fails all of them at once: a correct,
+ * server-rendered English page hydrates into Bangla chrome, and the language
+ * switcher offers `/en/en.html`.
+ *
+ * Normalising once, at the single place the pathname enters the tree, is
+ * cheaper and harder to forget than hardening each comparison.
+ */
+export function cleanRoute(pathname: string) {
+  let route = pathname
+  if (route.endsWith('/index.html')) route = route.slice(0, -'/index.html'.length)
+  else if (route.endsWith('.html')) route = route.slice(0, -'.html'.length)
+  if (route.length > 1 && route.endsWith('/')) route = route.slice(0, -1)
+  return route || '/'
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -48,6 +48,15 @@ const nextConfig = {
   // Content is a static asset. The small native Worker in worker/ owns only
   // /api/*, so adding guides does not increase the Worker script bundle.
   turbopack: { root: projectRoot },
+  // `next dev` and `next build` otherwise share one .next directory, and a dev
+  // server left running in an editor writes into it while a build is reading
+  // it. That does not fail loudly: builds die on a different random route each
+  // time ("Cannot find module for page", "Failed to collect page data"), or
+  // worse, succeed and export a stale client chunk, so a fix appears to have
+  // been deployed when the old code shipped. Give dev its own directory and
+  // the two stop touching the same files. Nothing else reads .next-dev; the
+  // build tooling (postbuild-seo, build-output) is production-only.
+  ...(isDevelopment ? { distDir: '.next-dev' } : {}),
   basePath,
   ...(isDevelopment
     ? {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "backlog:status": "npm run manifest && node scripts/backlog-status.mjs",
     "lint:bangla": "node scripts/bangla-lint.mjs",
     "lint:routes": "node scripts/route-lint.mjs",
-    "test:contribute": "node --experimental-strip-types --test app/lib/contributable-path.test.mjs app/lib/contribution-markdown.test.mjs app/lib/contribution-draft.test.mjs app/lib/contribution-media.test.mjs",
+    "test:contribute": "node --experimental-strip-types --test app/lib/contributable-path.test.mjs app/lib/contribution-markdown.test.mjs app/lib/contribution-draft.test.mjs app/lib/contribution-media.test.mjs app/lib/clean-route.test.mjs",
     "test:contributors": "node --test scripts/contributor-data.test.mjs app/lib/contributor-leaderboard.test.mjs",
     "seo:audit": "node scripts/seo-audit.mjs",
     "seo:indexnow": "node scripts/submit-indexnow.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,9 +23,21 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "worker", "cloudflare-env.d.ts"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    ".next-dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "worker",
+    "cloudflare-env.d.ts"
+  ]
 }


### PR DESCRIPTION
## What changed

- Normalize literal static-export URLs such as `/en.html`, `/en/index.html`, and trailing-slash variants before the application determines locale or builds language-switch links.
- Add focused route-normalization tests to the contribution test suite.
- Give `next dev` its own `.next-dev` build directory, include its generated types in TypeScript, and keep it out of Git.

## Why

Static hosts can serve exported `.html` files without redirecting to the clean URL. That could make an English page hydrate with Bangla chrome or produce a language-switch URL such as `/en/en.html`.

Development and production builds also shared `.next`, allowing a running development server to modify files while `next build` was reading them. Separating the directories prevents intermittent missing-page errors and stale output.

## Impact

Readers get consistent locale handling across equivalent static URLs. Contributors and maintainers can run the development server and production builds without the two processes competing over the same build artifacts.

## Validation

- `npm run test:contribute` — 44 tests passed
- `npm run build` — route, media, and citation checks passed; static export, Pagefind, and SEO audit completed successfully