### PR TITLE
ci: validate the contributor snapshot before it reaches main

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # Don't leave the token in .git/config for the build steps to reach.
+          # Don't make checkout's Git credentials available to the build steps.
           persist-credentials: false
 
       - uses: actions/setup-node@v7
@@ -39,6 +39,12 @@ jobs:
 
       - name: Citation guardrail tests
         run: npm run test:citations
+
+      - name: Contributor recognition tests
+        run: npm run test:contributors
+
+      - name: Contribution flow tests
+        run: npm run test:contribute
 
       - name: Build Cloudflare deployment
         run: npm run build:worker

--- a/.github/workflows/refresh-contributors.yml
+++ b/.github/workflows/refresh-contributors.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
 
     # main takes changes through pull requests, so the snapshot arrives as one
     # too: push the branch (contents), open it and let it merge itself
@@ -25,6 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Validation should not inherit the job's write-capable Git credentials.
+          persist-credentials: false
 
       - uses: actions/setup-node@v7
         with:
@@ -35,26 +38,44 @@ jobs:
         run: npm ci
 
       - name: Refresh contributor snapshot
-        run: npm run contributors:refresh
+        id: refresh
+        run: |
+          npm run contributors:refresh
+          if git diff --quiet app/generated/contributors.json; then
+            echo "Snapshot unchanged — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Open a pull request if the snapshot changed
+      # A PR created or updated with the repository's GITHUB_TOKEN creates
+      # `pull_request` runs that wait for manual approval, so this unattended bot
+      # cannot rely on PR checks. The snapshot decides the contributor route set,
+      # manifest entries and proof cards, so validate it here before the push.
+      - name: Validate the refreshed snapshot
+        if: steps.refresh.outputs.changed == 'true'
+        run: |
+          npm run test:contributors
+          npm run build:worker
+          node scripts/check-static-assets.mjs
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'
+
+      - name: Open a pull request with the snapshot
+        if: steps.refresh.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: chore/contributors
         run: |
-          git diff --quiet app/generated/contributors.json && {
-            echo "Snapshot unchanged — nothing to do."
-            exit 0
-          }
-
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add app/generated/contributors.json
           git commit -m "chore: refresh contributor snapshot"
           # The branch is disposable and always one commit ahead of main.
+          gh auth setup-git --hostname github.com
           git push --force origin "$BRANCH"
 
           if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then

--- a/scripts/contributor-data.mjs
+++ b/scripts/contributor-data.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { isDeepStrictEqual } from 'node:util'
 import {
   MAX_PROFILE_TEXT_LENGTH,
   ROLE_IDS,
@@ -854,8 +855,39 @@ export async function writeSnapshotAtomically(outputPath, snapshot) {
   }
 }
 
+async function readValidSnapshot(outputPath) {
+  let source
+  try {
+    source = await fs.readFile(outputPath, 'utf8')
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null
+    throw error
+  }
+
+  try {
+    const snapshot = JSON.parse(source)
+    validatePublicSnapshot(snapshot)
+    const refreshedAt = new Date(snapshot.refreshedAt)
+    if (Number.isNaN(refreshedAt.valueOf()) || refreshedAt.toISOString() !== snapshot.refreshedAt) {
+      return null
+    }
+    return snapshot
+  } catch {
+    return null
+  }
+}
+
+function snapshotContents(snapshot) {
+  const { refreshedAt: _refreshedAt, ...contents } = snapshot
+  return contents
+}
+
 export async function refreshContributorFile(options) {
   const snapshot = await buildContributorSnapshot(options)
+  const current = await readValidSnapshot(options.outputPath)
+  if (current && isDeepStrictEqual(snapshotContents(current), snapshotContents(snapshot))) {
+    return current
+  }
   await writeSnapshotAtomically(options.outputPath, snapshot)
   return snapshot
 }

--- a/scripts/contributor-data.test.mjs
+++ b/scripts/contributor-data.test.mjs
@@ -749,6 +749,108 @@ test('API failure preserves the last good snapshot', async () => {
   }
 })
 
+test('an unchanged refresh preserves the existing snapshot timestamp', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'deshi-contributors-unchanged-'))
+  const outputPath = path.join(directory, 'contributors.json')
+  const alice = profile('alice')
+  const options = {
+    policy: policy([alice]),
+    ledger: ledger([alice], [event(1, 'alice')]),
+    targetCatalog: targetCatalog('/guides/example'),
+    outputPath,
+    fetchImpl: githubMock([pull(1, 'alice')])
+  }
+  const original = await buildContributorSnapshot({
+    ...options,
+    now: new Date('2026-08-18T04:00:00Z')
+  })
+  const originalSource = `${JSON.stringify(original, null, 2)}\n`
+  const originalMtime = new Date('2026-08-18T04:00:00Z')
+  await fs.writeFile(outputPath, originalSource)
+  await fs.utimes(outputPath, originalMtime, originalMtime)
+
+  try {
+    const refreshed = await refreshContributorFile({
+      ...options,
+      now: new Date('2026-08-19T04:00:00Z')
+    })
+
+    assert.deepEqual(refreshed, original)
+    assert.equal(await fs.readFile(outputPath, 'utf8'), originalSource)
+    assert.equal((await fs.stat(outputPath)).mtimeMs, originalMtime.valueOf())
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('a refresh repairs a malformed existing snapshot timestamp', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'deshi-contributors-timestamp-'))
+  const outputPath = path.join(directory, 'contributors.json')
+  const alice = profile('alice')
+  const options = {
+    policy: policy([alice]),
+    ledger: ledger([alice], [event(1, 'alice')]),
+    targetCatalog: targetCatalog('/guides/example'),
+    outputPath,
+    fetchImpl: githubMock([pull(1, 'alice')])
+  }
+  const malformed = await buildContributorSnapshot({
+    ...options,
+    now: new Date('2026-08-18T04:00:00Z')
+  })
+  malformed.refreshedAt = 'not-a-timestamp'
+  await fs.writeFile(outputPath, `${JSON.stringify(malformed, null, 2)}\n`)
+
+  try {
+    const refreshed = await refreshContributorFile({
+      ...options,
+      now: new Date('2026-08-19T04:00:00Z')
+    })
+    const saved = JSON.parse(await fs.readFile(outputPath, 'utf8'))
+
+    assert.equal(refreshed.refreshedAt, '2026-08-19T04:00:00.000Z')
+    assert.deepEqual(saved, refreshed)
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('a substantive refresh replaces the snapshot and advances its timestamp', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'deshi-contributors-changed-'))
+  const outputPath = path.join(directory, 'contributors.json')
+  const alice = profile('alice')
+  const sourceLedger = ledger([alice], [event(1, 'alice')])
+  const options = {
+    policy: policy([alice]),
+    ledger: sourceLedger,
+    targetCatalog: targetCatalog('/guides/example'),
+    outputPath,
+    fetchImpl: githubMock([pull(1, 'alice')])
+  }
+
+  try {
+    await refreshContributorFile({
+      ...options,
+      now: new Date('2026-08-18T04:00:00Z')
+    })
+    sourceLedger.events[0].summary.en = 'Updated contribution'
+
+    const refreshed = await refreshContributorFile({
+      ...options,
+      now: new Date('2026-08-19T04:00:00Z')
+    })
+    const saved = JSON.parse(await fs.readFile(outputPath, 'utf8'))
+
+    assert.equal(refreshed.refreshedAt, '2026-08-19T04:00:00.000Z')
+    assert.equal(saved.events[0].summary.en, 'Updated contribution')
+    assert.deepEqual(saved, refreshed)
+    assert.doesNotThrow(() => validatePublicSnapshot(saved))
+    assert.deepEqual(await fs.readdir(directory), ['contributors.json'])
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true })
+  }
+})
+
 test('a failed GitHub avatar lookup preserves the last good snapshot', async () => {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'deshi-contributor-avatar-'))
   const outputPath = path.join(directory, 'contributors.json')

--- a/scripts/harden-github.sh
+++ b/scripts/harden-github.sh
@@ -61,11 +61,11 @@ gh api -X PATCH "repos/$REPO/code-scanning/default-setup" \
 
 # Ruleset notes
 #
-# No "required_status_checks" rule. The PR checks would never report on the
-# contributor-snapshot PR: GitHub does not start workflows for anything the
-# built-in GITHUB_TOKEN pushes or opens, so a required check would stay
-# "expected" forever and that PR would never merge. Every human and App PR
-# still runs PR checks, they are just not a hard gate.
+# No "required_status_checks" rule. A contributor-snapshot PR created or updated
+# with the repository's GITHUB_TOKEN creates `pull_request` runs that wait for
+# manual approval, so a required check would leave this unattended PR "expected"
+# forever. Every human and App PR still runs PR checks, they are just not a hard
+# gate.
 #
 # To make them a hard gate later: give the refresh-contributors workflow a
 # token from the org's GitHub App (actions/create-github-app-token, with


### PR DESCRIPTION
## কী বদলেছে · What changed

- Validate a changed contributor snapshot inside the unattended refresh job before its branch is pushed.
- Preserve the committed snapshot and `refreshedAt` value when public contributor data is unchanged, while repairing malformed snapshots.
- Run contributor tests, the production worker build, and the static-asset budget for substantive refreshes.
- Keep checkout credentials unavailable during validation and authenticate only the final write step.
- Add the contributor and contribution suites to normal pull-request checks.

## কেন · Why

Pull requests created or updated with the repository's `GITHUB_TOKEN` create `pull_request` runs that wait for approval, so the unattended refresh cannot rely on those checks before merging. The snapshot now controls contributor routes, manifest entries, and proof cards. Separately, its timestamp previously made every daily refresh appear changed, creating timestamp-only pull requests and unnecessary builds.

## নিজের কম্পিউটারে চালানো চেক · Local checks

- [x] `npm run test:contributors` — 58/58
- [x] `npm run test:contribute` — 51/51
- [x] `npm run test:media` — 18/18
- [x] `npm run test:citations` — 36/36
- [x] `npm run build:worker`
- [x] `npm run check:worker`
- [x] `node scripts/check-static-assets.mjs`
- [x] `npm run lint:bangla -- --strict`
- [x] Workflow YAML, shell syntax, and `git diff --check`
