### PR TITLE
Hide edit actions on non-editable pages

### DIFF
--- a/app/components/LocalizedLayout.tsx
+++ b/app/components/LocalizedLayout.tsx
@@ -49,6 +49,23 @@ function sourceFileFor(pathname: string) {
   return `app/(contents)/(bn)${pathname === '/' ? '' : pathname}/page.mdx`
 }
 
+/**
+ * The server allowlist makes this a security-independent UX guard. These
+ * markers are rendered with the page, so the shell can avoid shipping a route
+ * catalogue merely to learn whether the visible content lives in the MDX.
+ */
+function articleSupportsInlineEdit(article: HTMLElement | null) {
+  if (!article) return true
+  if (article.querySelector('[data-pagefind-meta="stub"]')) return false
+
+  const directChildren = Array.from(article.children)
+  const hasSectionIndex = directChildren.some(
+    (child) => child.getAttribute('data-inline-edit-source') === 'section-index'
+  )
+  const hasAuthoredSection = directChildren.some((child) => child.tagName === 'H2')
+  return !hasSectionIndex || hasAuthoredSection
+}
+
 function formatDate(iso: string | null, isEn: boolean) {
   if (!iso) return null
   try {
@@ -305,7 +322,13 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
   // a page nobody can read. Drop the page-contribution chrome; the 404 body
   // carries its own way out.
   const isNotFound = pathname === '/_not-found' || pathname === '/en/_not-found'
-  const { showContentTabs, showPageActions } = pageChromePolicy(pathname)
+  const {
+    showContentTabs,
+    showPageActions,
+    showEditAction: routeShowsEditAction
+  } = pageChromePolicy(pathname)
+  const [sourceSupportsEdit, setSourceSupportsEdit] = useState(true)
+  const showEditAction = routeShowsEditAction && sourceSupportsEdit
   const showPageChrome =
     !isPrivateReview &&
     !isCredits &&
@@ -356,13 +379,23 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
       setAuthToken(stored.token)
     }
     const wantsEdit = new URLSearchParams(window.location.search).get('action') === 'edit'
-    if (!wantsEdit || pathname === '/' || pathname === '/en' || isPrivateReview || isCredits || isNotFound) return
+    if (
+      !wantsEdit ||
+      !routeShowsEditAction ||
+      !articleSupportsInlineEdit(articleRef.current) ||
+      pathname === '/' ||
+      pathname === '/en' ||
+      isPrivateReview ||
+      isCredits ||
+      isNotFound
+    ) return
     if (stored) setIsEditing(true)
     else openAuth()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const enterEdit = useCallback(() => {
+    if (!routeShowsEditAction || !articleSupportsInlineEdit(articleRef.current)) return
     scrollBeforeEdit.current = window.scrollY
     setFlash(null)
     setIsEditing(true)
@@ -371,7 +404,7 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
       url.searchParams.set('action', 'edit')
       window.history.pushState({ editing: true }, '', url)
     }
-  }, [])
+  }, [routeShowsEditAction])
 
   const exitEdit = useCallback((result?: SubmitResult) => {
     setIsEditing(false)
@@ -390,6 +423,16 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
   const handleExit = useCallback(() => exitEdit(), [exitEdit])
   const handleSubmitted = useCallback((result: SubmitResult) => exitEdit(result), [exitEdit])
 
+  // The route policy handles pages whose source ownership is known from the
+  // URL. Rendered markers cover stubs and thin SectionIndex shells without
+  // putting hundreds of route strings in every reader's JavaScript bundle.
+  useEffect(() => {
+    const supportsEdit = routeShowsEditAction && articleSupportsInlineEdit(articleRef.current)
+    setSourceSupportsEdit(supportsEdit)
+    const hasEditQuery = new URLSearchParams(window.location.search).get('action') === 'edit'
+    if (!supportsEdit && (isEditing || hasEditQuery)) exitEdit()
+  }, [exitEdit, isEditing, pathname, routeShowsEditAction])
+
   // The server rejected the stored token. Forget it here so the next press of
   // এডিট offers a fresh sign-in rather than the same failure again.
   const handleSessionExpired = useCallback(() => {
@@ -404,6 +447,7 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
   }
 
   function handleContribute() {
+    if (!showEditAction || !articleSupportsInlineEdit(articleRef.current)) return
     if (session && authToken) enterEdit()
     else openAuth()
   }
@@ -411,7 +455,7 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
   function handleAuthenticated(user: UserInfo, token: string) {
     setSession(user)
     setAuthToken(token)
-    if (!isEditing) enterEdit()
+    if (!isEditing && showEditAction) enterEdit()
   }
 
   function handleRead() {
@@ -762,7 +806,9 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
                 </div>
               )}
               {showPageActions && (
-                <div className="article-actions">
+                <div
+                  className={`article-actions${showEditAction ? '' : ' article-actions--without-edit'}`}
+                >
                   {isEditing ? (
                     <button type="button" className="act-read tab-action-btn" onClick={handleRead}>
                       {tabs.read}
@@ -773,16 +819,18 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
                     </span>
                   )}
 
-                  {isEditing ? (
-                    <span className="act-edit is-current" aria-current="page">
-                      <ActionPencil />
-                      {tabs.edit}
-                    </span>
-                  ) : (
-                    <button type="button" className="act-edit tab-action-btn" onClick={handleContribute}>
-                      <ActionPencil />
-                      {tabs.edit}
-                    </button>
+                  {showEditAction && (
+                    isEditing ? (
+                      <span className="act-edit is-current" aria-current="page">
+                        <ActionPencil />
+                        {tabs.edit}
+                      </span>
+                    ) : (
+                      <button type="button" className="act-edit tab-action-btn" onClick={handleContribute}>
+                        <ActionPencil />
+                        {tabs.edit}
+                      </button>
+                    )
                   )}
 
                   <a className="act-history" href={`${REPO_URL}/commits/main/${file}`} target="_blank" rel="noopener noreferrer">
@@ -827,7 +875,7 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
             </div>
           )}
 
-          {isEditing && !isPrivateReview && (
+          {isEditing && showEditAction && !isPrivateReview && (
             <ContributionEditor
               pathname={pathname}
               isEn={isEn}
@@ -923,10 +971,17 @@ export default function LocalizedLayout({ children }: LocalizedLayoutProps) {
             <footer className="article-footer">
               <h2>{isEn ? 'Help improve this page' : 'এই পেজ আরও ভালো করুন'}</h2>
               <div className="contrib-row">
-                <a href={`${REPO_URL}/edit/main/${file}`} target="_blank" rel="noopener noreferrer">
-                  <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" /></svg>
-                  {isEn ? 'Edit on GitHub' : 'GitHub-এ এডিট করুন'}
-                </a>
+                {showEditAction && (
+                  <a
+                    className="contrib-edit"
+                    href={`${REPO_URL}/edit/main/${file}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" /></svg>
+                    {isEn ? 'Edit on GitHub' : 'GitHub-এ এডিট করুন'}
+                  </a>
+                )}
                 <a href={issueUrl} target="_blank" rel="noopener noreferrer">
                   <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 9v4m0 4h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" /></svg>
                   {isEn ? 'Report a mistake' : 'ফিডব্যাক দিন'}

--- a/app/components/SectionIndex.tsx
+++ b/app/components/SectionIndex.tsx
@@ -71,7 +71,11 @@ export default function SectionIndex({ section, locale = 'bn' }: SectionIndexPro
   const remaining = total - written
 
   return (
-    <section className="section-index" data-pagefind-ignore>
+    <section
+      className="section-index"
+      data-inline-edit-source="section-index"
+      data-pagefind-ignore
+    >
       <h2 id={isDirectory ? (isEn ? 'all-directories' : 'সব-ডিরেক্টরি') : (isEn ? 'all-guides-in-this-section' : 'এই-বিভাগের-সব-গাইড')}>
         {isDirectory ? (isEn ? 'All directories' : 'সব ডিরেক্টরি') : (isEn ? 'All guides in this section' : 'এই বিভাগের সব গাইড')}
       </h2>

--- a/app/globals.css
+++ b/app/globals.css
@@ -615,6 +615,18 @@ a.tab {
   stroke-linejoin: round;
 }
 
+/* The route policy removes data-owned actions during SSR. These selectors are
+   the no-flash fallback for source states only the rendered article can reveal:
+   stubs and a SectionIndex shell with no authored section.
+   The client removes the same controls after hydration, and the API allowlist
+   independently rejects those routes. */
+.content-canvas:has(.article [data-pagefind-meta='stub'])
+  :is(.article-actions .act-edit, .article-footer .contrib-edit),
+.content-canvas:has(.article > [data-inline-edit-source='section-index']):not(:has(.article > h2))
+  :is(.article-actions .act-edit, .article-footer .contrib-edit) {
+  display: none;
+}
+
 /* --------------------------------------------------- breadcrumbs and meta */
 
 .article-lede {
@@ -3105,6 +3117,21 @@ a.is-stub-link:hover {
     gap: 12px;
     padding-bottom: 10px;
     font-size: 0.9rem;
+  }
+
+  /* Read is already the current view and History is intentionally desktop-only
+     here. Once Edit is ineligible, remove the otherwise empty mobile action
+     slot; an actions-only utility strip should disappear with it. */
+  .article-actions--without-edit,
+  .content-canvas:has(.article [data-pagefind-meta='stub']) .article-actions,
+  .content-canvas:has(.article > [data-inline-edit-source='section-index']):not(:has(.article > h2)) .article-actions {
+    display: none;
+  }
+
+  .article-tabs--actions-only:has(.article-actions--without-edit),
+  .content-canvas:has(.article [data-pagefind-meta='stub']) .article-tabs--actions-only,
+  .content-canvas:has(.article > [data-inline-edit-source='section-index']):not(:has(.article > h2)) .article-tabs--actions-only {
+    display: none;
   }
 
   .article-actions .act-history,

--- a/app/lib/inline-edit-policy.mjs
+++ b/app/lib/inline-edit-policy.mjs
@@ -1,0 +1,63 @@
+const DATA_OWNED_ROUTE = /^\/directory(?:\/|$)/
+const SECTION_INDEX_COMPONENT = /<SectionIndex\b/
+
+/**
+ * Removes the locale prefix so one content-ownership rule covers both trees.
+ * The caller already cleans export spellings such as /index.html.
+ *
+ * @param {string} pathname
+ */
+export function localeNeutralContentRoute(pathname) {
+  if (pathname === '/en' || pathname === '/en/') return '/'
+  if (pathname.startsWith('/en/')) return pathname.slice(3) || '/'
+  return pathname || '/'
+}
+
+/**
+ * Some rendered pages are views over another authored source. Opening their
+ * MDX shell in the browser editor promises control over content it does not
+ * contain: directory rows live in data/directory and the sitemap is generated.
+ *
+ * @param {string} pathname
+ */
+export function routeSupportsInlineEdit(pathname) {
+  const route = localeNeutralContentRoute(pathname)
+  return route !== '/sitemap' && !DATA_OWNED_ROUTE.test(route)
+}
+
+function hasAuthoredSection(source) {
+  let fence = null
+
+  for (const line of source.split(/\r?\n/)) {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/)
+    if (fenceMatch) {
+      const marker = fenceMatch[1]
+      if (fence === null) fence = marker
+      else if (marker[0] === fence[0] && marker.length >= fence.length) fence = null
+      continue
+    }
+    if (fence === null && /^ {0,3}##(?!#)\s+\S/.test(line)) return true
+  }
+
+  return false
+}
+
+/**
+ * Build-time counterpart to the rendered-page guard in LocalizedLayout.
+ * Stubs keep their purpose-built GitHub writing CTA. A top-level SectionIndex
+ * page remains browser-editable only when it also contains an authored section;
+ * nested guides may append the same index as a read-next aid.
+ *
+ * @param {{ slug?: string, source?: string, stub?: boolean }} page
+ */
+export function sourceSupportsInlineEdit({ slug = '', source = '', stub = false } = {}) {
+  if (stub || !routeSupportsInlineEdit(`/${slug}`)) return false
+  if (
+    !slug.includes('/') &&
+    SECTION_INDEX_COMPONENT.test(source) &&
+    !hasAuthoredSection(source)
+  ) {
+    return false
+  }
+  return true
+}

--- a/app/lib/page-chrome.test.mjs
+++ b/app/lib/page-chrome.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { cleanRoute } from './clean-route.ts'
+import { sourceSupportsInlineEdit } from './inline-edit-policy.mjs'
 import { pageChromePolicy } from './page-chrome.ts'
 
 test('utility and policy pages do not present Guide and Discussion as content tabs', () => {
@@ -26,32 +27,50 @@ test('home and contact omit the whole page-chrome strip', () => {
   for (const route of ['/', '/en', '/en/', '/contact', '/en/contact']) {
     assert.deepEqual(
       pageChromePolicy(route),
-      { showContentTabs: false, showPageActions: false },
+      { showContentTabs: false, showPageActions: false, showEditAction: false },
       route
     )
   }
 })
 
-test('non-guide pages retain useful edit and history actions', () => {
-  for (const route of ['/about', '/contribute', '/privacy', '/terms', '/sitemap', '/en/privacy']) {
-    assert.equal(pageChromePolicy(route).showPageActions, true, route)
+test('authored non-guide pages retain edit and history actions', () => {
+  for (const route of ['/about', '/contribute', '/privacy', '/terms', '/en/privacy']) {
+    assert.deepEqual(
+      pageChromePolicy(route),
+      { showContentTabs: false, showPageActions: true, showEditAction: true },
+      route
+    )
   }
 })
 
-test('guides and content collections retain the established content chrome', () => {
+test('guides and authored collections retain the established content chrome', () => {
   for (const route of [
     '/registration/private-limited',
     '/en/registration/private-limited',
-    '/tax',
     '/guides',
-    '/directory',
-    '/journeys'
+    '/journeys',
+    '/case-studies',
+    '/validation'
   ]) {
     assert.deepEqual(
       pageChromePolicy(route),
-      { showContentTabs: true, showPageActions: true },
+      { showContentTabs: true, showPageActions: true, showEditAction: true },
       route
     )
+  }
+})
+
+test('data-owned routes keep read and history without offering the MDX editor', () => {
+  for (const route of [
+    '/directory',
+    '/directory/investors',
+    '/en/directory/payment-gateways',
+    '/sitemap',
+    '/en/sitemap'
+  ]) {
+    const policy = pageChromePolicy(route)
+    assert.equal(policy.showPageActions, true, route)
+    assert.equal(policy.showEditAction, false, route)
   }
 })
 
@@ -66,7 +85,7 @@ test('static-export spellings resolve to the same page-chrome policy', () => {
   ]) {
     assert.deepEqual(
       pageChromePolicy(cleanRoute(route)),
-      { showContentTabs: false, showPageActions: true },
+      { showContentTabs: false, showPageActions: true, showEditAction: true },
       route
     )
   }
@@ -76,8 +95,71 @@ test('utility route names are exact rather than prefix matches', () => {
   for (const route of ['/privacy/notice-template', '/contact/customer-support', '/en/terms/term-sheets']) {
     assert.deepEqual(
       pageChromePolicy(route),
-      { showContentTabs: true, showPageActions: true },
+      { showContentTabs: true, showPageActions: true, showEditAction: true },
       route
     )
   }
+})
+
+test('source policy blocks stubs and thin generated shells', () => {
+  assert.equal(
+    sourceSupportsInlineEdit({
+      slug: 'funding/example',
+      source: '# Example\n\n<StubNotice path="funding/example" />',
+      stub: true
+    }),
+    false
+  )
+  assert.equal(
+    sourceSupportsInlineEdit({
+      slug: 'tax',
+      source: '# Tax\n\n> **Summary:** Start here.\n\n<SectionIndex section="tax" locale="en" />'
+    }),
+    false
+  )
+  assert.equal(
+    sourceSupportsInlineEdit({
+      slug: 'directory/investors',
+      source: '# Investors\n\n<DirectoryList category="investors" locale="en" />'
+    }),
+    false
+  )
+})
+
+test('source policy keeps rich hubs, all guides, and nested guides editable', () => {
+  assert.equal(
+    sourceSupportsInlineEdit({
+      slug: 'validation',
+      source: '# Validation\n\n## First step\n\nTalk to customers.\n\n<SectionIndex section="validation" locale="en" />'
+    }),
+    true
+  )
+  assert.equal(
+    sourceSupportsInlineEdit({ slug: 'guides', source: '# All topics\n\n## Start here' }),
+    true
+  )
+  assert.equal(
+    sourceSupportsInlineEdit({
+      slug: 'start-here/30-day-roadmap',
+      source: '# Roadmap\n\n<SectionIndex section="start-here" locale="en" />'
+    }),
+    true
+  )
+})
+
+test('Markdown headings inside code fences do not make a thin hub editable', () => {
+  assert.equal(
+    sourceSupportsInlineEdit({
+      slug: 'tax',
+      source: '# Tax\n\n```md\n## Example only\n```\n\n<SectionIndex section="tax" locale="en" />'
+    }),
+    false
+  )
+  assert.equal(
+    sourceSupportsInlineEdit({
+      slug: 'tax',
+      source: '# Tax\n\n````md\n```\n## Still example code\n````\n\n<SectionIndex section="tax" locale="en" />'
+    }),
+    false
+  )
 })

--- a/app/lib/page-chrome.ts
+++ b/app/lib/page-chrome.ts
@@ -1,6 +1,12 @@
+import {
+  localeNeutralContentRoute,
+  routeSupportsInlineEdit
+} from './inline-edit-policy.mjs'
+
 export interface PageChromePolicy {
   showContentTabs: boolean
   showPageActions: boolean
+  showEditAction: boolean
 }
 
 const NON_CONTENT_ROUTES = new Set([
@@ -15,22 +21,18 @@ const NON_CONTENT_ROUTES = new Set([
 
 const CHROMELESS_ROUTES = new Set(['/', '/contact'])
 
-function localeNeutralRoute(pathname: string) {
-  if (pathname === '/en' || pathname === '/en/') return '/'
-  if (pathname.startsWith('/en/')) return pathname.slice(3) || '/'
-  return pathname
-}
-
 /**
  * The Guide/Discussion pair describes editorial content, not project,
  * policy, or task pages. Page actions stay independent so transparent history
  * and reviewed edits remain available wherever they are useful.
  */
 export function pageChromePolicy(pathname: string): PageChromePolicy {
-  const route = localeNeutralRoute(pathname)
+  const route = localeNeutralContentRoute(pathname)
+  const showPageActions = !CHROMELESS_ROUTES.has(route)
 
   return {
     showContentTabs: !NON_CONTENT_ROUTES.has(route),
-    showPageActions: !CHROMELESS_ROUTES.has(route)
+    showPageActions,
+    showEditAction: showPageActions && routeSupportsInlineEdit(route)
   }
 }

--- a/scripts/build-manifest.mjs
+++ b/scripts/build-manifest.mjs
@@ -22,6 +22,7 @@ import {
   canonicalUrl,
 } from "../app/seo.config.mjs";
 import { prepareContributorSnapshot } from "../app/lib/contributor-leaderboard.mjs";
+import { sourceSupportsInlineEdit } from "../app/lib/inline-edit-policy.mjs";
 import { isWrittenGuide } from "./content-guide.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -154,6 +155,7 @@ const llmsPages = {};
 const localeCounts = {};
 const localeManifests = {};
 const seoPages = [];
+const inlineEditableRoutes = new Set();
 
 for (const locale of LOCALES) {
   if (!fs.existsSync(locale.dir)) continue;
@@ -168,6 +170,9 @@ for (const locale of LOCALES) {
       source.includes("<StubNotice") || rendersEmptyDirectory(source);
     const route =
       rel === "" ? locale.routePrefix || "/" : `${locale.routePrefix}/${rel}`;
+    if (sourceSupportsInlineEdit({ slug: rel, source, stub: isStub })) {
+      inlineEditableRoutes.add(route);
+    }
     const repoPath = path.relative(root, filePath).split(path.sep).join("/");
     const date = gitDates.modified.get(repoPath) || null;
     const published = gitDates.published.get(repoPath) || null;
@@ -286,13 +291,16 @@ if (fs.existsSync(contributorSnapshotPath)) {
 }
 
 // Route allowlist for the inline contribution editor. Source paths and locale
-// are derived only after a route passes this generated allowlist.
+// are derived only after a route passes this generated allowlist. Stubs keep
+// their purpose-built GitHub writing CTA; generated data views and thin section
+// shells do not pretend that their locked MDX contains the page readers see.
 // Landing pages ("/" and "/en") are excluded — they are hubs, not articles.
 {
   const contributable = [];
   for (const locale of LOCALES) {
     for (const page of llmsPages[locale.key] || []) {
       if (page.route === "/" || page.route === "/en") continue;
+      if (!inlineEditableRoutes.has(page.route)) continue;
       contributable.push(page.route);
     }
   }


### PR DESCRIPTION
## Summary

- hide inline and GitHub edit actions on stubs, directory/data pages, the sitemap, and thin section shells
- preserve history, mistake reporting, and the purpose-built stub writing path
- keep substantial hubs such as All Guides editable
- filter the generated contribution allowlist so direct editor/API requests follow the same policy

## Validation

- `npm run test:contribute` — 55 tests passed
- `npx tsc --noEmit`
- `npm run build` — 936 pages built; Pagefind and SEO audits passed
